### PR TITLE
Added craft_items to machine definition for recipe creation

### DIFF
--- a/home_vending_machines/api.lua
+++ b/home_vending_machines/api.lua
@@ -49,6 +49,16 @@ local function reg_simple(name, def)
             end
         end
     })
+    if def.craft_items ~= nil then
+        minetest.register_craft({
+            output = name,
+            recipe = {
+                {"default:steel_ingot",def.craft_items[1],"default:steel_ingot"},
+                {"default:steel_ingot",def.craft_items[2],"default:steel_ingot"},
+                {"default:steel_ingot","default:copperblock","default_steel_ingot"}
+            }
+        })
+    end
 end
 
 function home_vending_machines.register_machine(type, name, def)

--- a/home_vending_machines/machines.lua
+++ b/home_vending_machines/machines.lua
@@ -7,7 +7,8 @@ home_vending_machines.register_machine("simple", "home_workshop_misc:soda_machin
     sounds = nil,
     _vmachine = {
         item = "home_vending_machines:soda_can"
-    }
+    },
+    craft_items = {"group:vessel","group:food_sugar"}
 })
 
 home_vending_machines.register_machine("simple", "home_vending_machines:drink_machine", {
@@ -16,7 +17,8 @@ home_vending_machines.register_machine("simple", "home_vending_machines:drink_ma
     sounds = nil,
     _vmachine = {
         item = {"home_vending_machines:soda_can", "home_vending_machines:water_bottle"}
-    }
+    },
+    craft_items = {"group:vessel","default:steel_ingot"}
 })
 
 home_vending_machines.register_machine("simple", "home_vending_machines:sweet_machine", {
@@ -25,5 +27,6 @@ home_vending_machines.register_machine("simple", "home_vending_machines:sweet_ma
     sounds = nil,
     _vmachine = {
         item = "home_vending_machines:soda_can"
-    }
+    },
+    craft_items = {"group:food_sugar", "default:steel_ingot"}
 })


### PR DESCRIPTION
There should be some recipes now to craft the machines. They are in the machine definition so the recipies have a consistent feel. They use groups to make them hopefully more portable.