### PR TITLE
Fix use_texture_alpha warnings in Minetest 5.9

### DIFF
--- a/computers/computers.lua
+++ b/computers/computers.lua
@@ -21,6 +21,7 @@ minetest.register_node("computers:vanio", {
 	tiles = {"computers_laptop.png"},
 	paramtype = "light",
 	paramtype2 = "facedir",
+	use_texture_alpha = "clip",
 	light_source = 4,
 	groups = {snappy=3},
 	walkable = false,
@@ -41,6 +42,7 @@ minetest.register_node("computers:vanio_off", {
 	tiles = {"computers_laptop.png"},
 	paramtype = "light",
 	paramtype2 = "facedir",
+	use_texture_alpha = "clip",
 	groups = {snappy=3, not_in_creative_inventory=1},
 	walkable = false,
 	selection_box = {
@@ -171,6 +173,7 @@ minetest.register_node("computers:router", {
 	}, --"computers_router_f.png"},
 	paramtype = "light",
 	paramtype2 = "facedir",
+	use_texture_alpha = "clip",
 	walkable = false,
 	groups = {snappy=3},
 	sound = default and default.node_sound_wood_defaults() or nil,
@@ -221,6 +224,7 @@ minetest.register_node("computers:server", {
 	inventory_image = "computers_server_inv.png",
 	paramtype = "light",
 	paramtype2 = "facedir",
+	use_texture_alpha = "clip",
 	groups = {snappy=3},
 	selection_box = {
 		type = "fixed",
@@ -260,6 +264,7 @@ minetest.register_node("computers:server_on", {
 	inventory_image = "computers_server_inv.png",
 	paramtype = "light",
 	paramtype2 = "facedir",
+	use_texture_alpha = "clip",
 	groups = {snappy=3,not_in_creative_inventory=1},
 	selection_box = {
 		type = "fixed",
@@ -287,6 +292,7 @@ minetest.register_node("computers:printer", {
 			"computers_printer_r.png","computers_printer_b.png","computers_printer_f.png"},
 	paramtype = "light",
 	paramtype2 = "facedir",
+	use_texture_alpha = "clip",
 	walkable = true,
 	groups = {snappy=3},
 	sound = default and default.node_sound_wood_defaults() or nil,

--- a/computers/init.lua
+++ b/computers/init.lua
@@ -11,6 +11,7 @@ computers.register = function (name, def)
 		drawtype = "nodebox",
 		paramtype = "light",
 		paramtype2 = "facedir",
+		use_texture_alpha = "clip",
 		description = cdef.description,
 		inventory_image = cdef.inventory_image,
 		groups = {snappy=2, choppy=2, oddly_breakable_by_hand=2},
@@ -37,6 +38,7 @@ computers.register = function (name, def)
 		drawtype = "nodebox",
 		paramtype = "light",
 		paramtype2 = "facedir",
+		use_texture_alpha = "clip",
 		groups = {snappy=2, choppy=2, oddly_breakable_by_hand=2, not_in_creative_inventory=1},
 		tiles = {
 			(TEXPFX.."tp"..(cdef.tiles_off.top    and "_off" or "")..".png"),

--- a/modpack.conf
+++ b/modpack.conf
@@ -1,1 +1,2 @@
 name = home_workshop_modpack
+min_minetest_version = 5.4.0


### PR DESCRIPTION
Next step for https://github.com/Archtec-io/bugtracker/issues/137